### PR TITLE
allow to install copper with any version of scikit-learn >= 0.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(
     long_description=open('README.txt').read(),
     install_requires=[
         "pandas>= 0.11",
-        "scikit-learn == 0.13.1"
+        "scikit-learn >= 0.13.1"
     ],
 )


### PR DESCRIPTION
Fixed a bug with the installation of copper so it can work with any version of scikit-learn >= 0.13
